### PR TITLE
RSP-1208: Add validation of penalty group submission payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "js-sha256": "^0.7.1",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "rsp-validation": "^1.3.0",
+    "rsp-validation": "^1.5.0",
     "serverless-dynamodb-client": "0.0.2",
     "uuid": "^3.1.0"
   }

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -18,13 +18,11 @@ export default class PenaltyGroup {
 	}
 
 	async createPenaltyGroup(body, callback) {
-		if (process.env.DO_PENALTY_GROUP_VALIDATION) {
-			const validationResult = Validation.penaltyGroupValidation(body);
+		const validationResult = Validation.penaltyGroupValidation(body);
 
-			if (!validationResult.valid) {
-				const errMsg = validationResult.error.message;
-				return callback(null, createResponse({ statusCode: 400, body: `Bad request: ${errMsg}` }));
-			}
+		if (!validationResult.valid) {
+			const errMsg = validationResult.error.message;
+			return callback(null, createResponse({ statusCode: 400, body: `Bad request: ${errMsg}` }));
 		}
 
 		const penaltyGroup = this._enrichPenaltyGroupRequest(body);
@@ -79,7 +77,10 @@ export default class PenaltyGroup {
 		const lengthOfPaddedSiteCode = 4;
 		const numberOfZeros = lengthOfPaddedSiteCode - lengthOfSiteCode - numberOfOnes;
 		const paddedSiteCode = `${'1'.repeat(numberOfOnes)}${'0'.repeat(numberOfZeros)}${absoluteSiteCode}`;
-		const concatId = parseInt(`${timestamp}${paddedSiteCode}`, 10);
+
+		const parsedTimestamp = timestamp.toFixed(3) * 1000;
+
+		const concatId = parseInt(`${parsedTimestamp}${paddedSiteCode}`, 10);
 		const encodedConcatId = concatId.toString(36);
 		return encodedConcatId;
 	}

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -42,7 +42,7 @@ describe('penaltyGroups', () => {
 		context('a new penalty group', () => {
 			it('should return created penalty group with generated ID', (done) => {
 				const fakePenaltyGroupPayload = {
-					Timestamp: 1532528872164,
+					Timestamp: 1532945465.234729,
 					SiteCode: -72,
 					Location: 'Trowell Services',
 					VehicleRegistration: '11 ABC',
@@ -94,8 +94,8 @@ describe('penaltyGroups', () => {
 					.expect('Content-Type', 'application/json')
 					.end((err, res) => {
 						if (err) throw err;
-						expect(res.body.ID).toBe('46wd0g1mwds');
-						expect(res.body.Timestamp).toBe(1532528872164);
+						expect(res.body.ID).toBe('46xu68x7wps');
+						expect(res.body.Timestamp).toBe(1532945465.234729);
 						expect(res.body.Location).toBe('Trowell Services');
 						expect(res.body.VehicleRegistration).toBe('11 ABC');
 						expect(res.body.TotalAmount).toBe(230);


### PR DESCRIPTION
* Bump version of rsp-validation to 1.5.0
* Remove feature flag around penalty group validation call
* Update penalty group integration test with timestamp format matching
  that sent by the iOS app
* Should not be merged until `rsp-validation` version `1.5.0` is published to npm