### PR TITLE
RSP-1226: Implement endpoint for listing penalty groups after a given offset

### DIFF
--- a/mock-data/fake-penalty-groups.json
+++ b/mock-data/fake-penalty-groups.json
@@ -1,12 +1,14 @@
 [
   {
-    "ID": "15317465650001337",
+    "ID": "46xu68x7o6b",
     "PaymentStatus": "UNPAID",
-    "Timestamp": 1521311200,
-    "Offset": 1521311200.345,
+    "Timestamp": 1532945465.234729,
+    "Offset": 1532945466.112,
     "VehicleRegistration": "11 ABC",
     "Location": "Trowell Services",
     "TotalAmount": 130,
+    "SiteCode": 3,
+    "Origin": "APP",
     "PenaltyDocumentIds": [
       "820500000877_FPN",
       "820500000878_FPN"

--- a/src/functions/listGroups.js
+++ b/src/functions/listGroups.js
@@ -1,0 +1,20 @@
+import { doc } from 'serverless-dynamodb-client';
+
+import PenaltyGroupService from '../services/penaltyGroups';
+
+const penaltyGroupService = new PenaltyGroupService(
+	doc,
+	process.env.DYNAMODB_PENALTY_DOC_TABLE,
+	process.env.DYNAMODB_PENALTY_GROUP_TABLE,
+);
+
+export default (event, context, callback) => {
+	const { offset } = event.queryStringParameters;
+	const numericOffset = Number(offset);
+
+	if (Number.isNaN(numericOffset)) {
+		return callback({ statusCode: 400, body: 'No numeric Offset provided' });
+	}
+
+	return penaltyGroupService.listPenaltyGroups(numericOffset, callback);
+};

--- a/src/functions/listGroups.js
+++ b/src/functions/listGroups.js
@@ -9,8 +9,8 @@ const penaltyGroupService = new PenaltyGroupService(
 );
 
 export default (event, context, callback) => {
-	const { offset } = event.queryStringParameters;
-	const numericOffset = Number(offset);
+	const { Offset } = event.queryStringParameters;
+	const numericOffset = Number(Offset);
 
 	if (Number.isNaN(numericOffset)) {
 		return callback({ statusCode: 400, body: 'No numeric Offset provided' });

--- a/src/functions/listGroups.unit.js
+++ b/src/functions/listGroups.unit.js
@@ -26,25 +26,25 @@ describe('listGroups', () => {
 	};
 
 	describe('when there is no offset provided', () => {
-		const offset = undefined;
+		const Offset = undefined;
 		it('should respond 400 without calling PenaltyGroupService', () => {
-			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			listGroups({ queryStringParameters: { Offset } }, {}, callbackSpy);
 			assert400ResponseWithNoPenaltySvcCall();
 		});
 	});
 
 	describe('when the offset provided is not numeric', () => {
-		const offset = 'abc';
+		const Offset = 'abc';
 		it('should respond 400 without calling PenaltyGroupService', () => {
-			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			listGroups({ queryStringParameters: { Offset } }, {}, callbackSpy);
 			assert400ResponseWithNoPenaltySvcCall();
 		});
 	});
 
 	describe('when a numeric offset string is provided', () => {
-		const offset = '1234567890.345';
+		const Offset = '1234567890.345';
 		it('should call PenaltyGroupService with offset and callback', () => {
-			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			listGroups({ queryStringParameters: { Offset } }, {}, callbackSpy);
 			sinon.assert.calledWith(penaltyGrpSvc, 1234567890.345, callbackSpy);
 		});
 	});

--- a/src/functions/listGroups.unit.js
+++ b/src/functions/listGroups.unit.js
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+
+import PenaltyGroup from '../services/penaltyGroups';
+import listGroups from '../functions/listGroups';
+
+describe('listGroups', () => {
+
+	let penaltyGrpSvc;
+	let callbackSpy;
+
+	beforeEach(() => {
+		penaltyGrpSvc = sinon.stub(PenaltyGroup.prototype, 'listPenaltyGroups');
+		callbackSpy = sinon.spy();
+	});
+
+	afterEach(() => {
+		PenaltyGroup.prototype.listPenaltyGroups.restore();
+	});
+
+	const assert400ResponseWithNoPenaltySvcCall = () => {
+		sinon.assert.calledWith(callbackSpy, sinon.match({
+			statusCode: 400,
+			body: 'No numeric Offset provided',
+		}));
+		sinon.assert.notCalled(penaltyGrpSvc);
+	};
+
+	describe('when there is no offset provided', () => {
+		const offset = undefined;
+		it('should respond 400 without calling PenaltyGroupService', () => {
+			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			assert400ResponseWithNoPenaltySvcCall();
+		});
+	});
+
+	describe('when the offset provided is not numeric', () => {
+		const offset = 'abc';
+		it('should respond 400 without calling PenaltyGroupService', () => {
+			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			assert400ResponseWithNoPenaltySvcCall();
+		});
+	});
+
+	describe('when a numeric offset string is provided', () => {
+		const offset = '1234567890.345';
+		it('should call PenaltyGroupService with offset and callback', () => {
+			listGroups({ queryStringParameters: { offset } }, {}, callbackSpy);
+			sinon.assert.calledWith(penaltyGrpSvc, 1234567890.345, callbackSpy);
+		});
+	});
+});

--- a/src/handler.js
+++ b/src/handler.js
@@ -2,6 +2,7 @@ import 'babel-polyfill';
 
 import auth from './functions/auth';
 import list from './functions/list';
+import listGroups from './functions/listGroups';
 import get from './functions/get';
 import create from './functions/create';
 import createPenaltyGroup from './functions/createPenaltyGroup';
@@ -17,6 +18,7 @@ import getDocumentByToken from './functions/getDocumentByToken';
 const handler = {
 	auth,
 	list,
+	listGroups,
 	get,
 	getDocumentByToken,
 	create,

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -60,7 +60,7 @@ export default class PenaltyGroup {
 				TableName: this.penaltyGroupTableName,
 				IndexName: 'ByOffset',
 				Limit: this.maxBatchSize,
-				KeyConditionExpression: '#Origin = :Origin and #Offset >= :Offset',
+				KeyConditionExpression: '#Origin = :Origin and #Offset > :Offset',
 				ExpressionAttributeNames: { '#Offset': 'Offset', '#Origin': 'Origin' },
 				ExpressionAttributeValues: { ':Offset': offsetFrom, ':Origin': 'APP' },
 			};

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -15,6 +15,7 @@ export default class PenaltyGroup {
 		this.db = db;
 		this.penaltyDocTableName = penaltyDocTableName;
 		this.penaltyGroupTableName = penaltyGroupTableName;
+		this.maxBatchSize = 75;
 	}
 
 	async createPenaltyGroup(body, callback) {
@@ -53,6 +54,25 @@ export default class PenaltyGroup {
 		}
 	}
 
+	async listPenaltyGroups(offsetFrom, callback) {
+		try {
+			const params = {
+				TableName: this.penaltyGroupTableName,
+				IndexName: 'ByOffset',
+				Limit: this.maxBatchSize,
+				KeyConditionExpression: '#Origin = :Origin and #Offset >= :Offset',
+				ExpressionAttributeNames: { '#Offset': 'Offset', '#Origin': 'Origin' },
+				ExpressionAttributeValues: { ':Offset': offsetFrom, ':Origin': 'APP' },
+			};
+
+			const result = await this.db.query(params).promise();
+			return callback(null, createResponse({ statusCode: 200, body: result }));
+		} catch (error) {
+			const resp = createResponse({ statusCode: 500, body: error });
+			return callback(null, resp);
+		}
+	}
+
 	_enrichPenaltyGroupRequest(body) {
 		const penGrp = { ...body };
 		const { Timestamp, SiteCode, Penalties } = penGrp;
@@ -61,6 +81,7 @@ export default class PenaltyGroup {
 		penGrp.TotalAmount = Penalties.reduce((total, pen) => pen.Value.penaltyAmount + total, 0);
 		penGrp.Offset = Date.now() / 1000;
 		penGrp.PaymentStatus = 'UNPAID';
+		penGrp.Origin = penGrp.Origin || appOrigin;
 		penGrp.Penalties.forEach((p) => {
 			p.inPenaltyGroup = true;
 			p.Hash = hashToken(p.ID, p.Value, p.Enabled);

--- a/src/services/penaltyGroups.unit.js
+++ b/src/services/penaltyGroups.unit.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-use-before-define */
+
+import expect from 'expect';
+import sinon from 'sinon';
+import { doc } from 'serverless-dynamodb-client';
+
+import PenaltyGroupService from './penaltyGroups';
+
+describe('PenaltyGroupService', () => {
+	let penaltyGroupSvc;
+	let mockDb;
+	let callbackSpy;
+
+	beforeEach(() => {
+		mockDb = sinon.stub(doc, 'query');
+		callbackSpy = sinon.spy(() => ('callback result'));
+		penaltyGroupSvc = new PenaltyGroupService(doc, 'penaltyDocuments', 'penaltyGroups');
+	});
+
+	afterEach(() => {
+		doc.query.restore();
+	});
+
+	describe('listPenaltyGroups', () => {
+		let groups;
+		const offset = 100;
+		beforeEach(() => {
+			groups = [
+				{
+					ID: '1234567890a',
+					offset: 101,
+				},
+				{
+					ID: 'abcdefghij0',
+					offset: 102,
+				},
+			];
+		});
+		describe('when database call is successful', () => {
+			beforeEach(() => {
+				const batchSize = 2;
+				penaltyGroupSvc.maxBatchSize = batchSize;
+				whenDbWithLimitAndOffset(mockDb, batchSize, offset)
+					.returns({
+						promise: () => Promise.resolve({
+							data: {
+								Items: groups,
+								Count: 2,
+								ScannedCount: 2,
+							},
+						}),
+					});
+			});
+			it('should respond 200 returning all data from the database response', async () => {
+				const result = await penaltyGroupSvc.listPenaltyGroups(offset, callbackSpy);
+
+				sinon.assert.calledWith(callbackSpy, null, sinon.match({
+					statusCode: 200,
+					body: JSON.stringify({ data: { Items: groups, Count: 2, ScannedCount: 2 } }),
+				}));
+				expect(result).toBe('callback result');
+			});
+		});
+
+		describe('when database throws an error', () => {
+			beforeEach(() => {
+				const batchSize = 100;
+				penaltyGroupSvc.maxBatchSize = batchSize;
+				whenDbWithLimitAndOffset(mockDb, batchSize, offset)
+					.throws({});
+			});
+			it('should return a 500 with the error', async () => {
+				const result = await penaltyGroupSvc.listPenaltyGroups(offset, callbackSpy);
+
+				sinon.assert.calledWith(callbackSpy, null, sinon.match({
+					statusCode: 500,
+					body: {},
+				}));
+				expect(result).toBe('callback result');
+			});
+		});
+	});
+});
+
+const whenDbWithLimitAndOffset = (mockDb, limit, offset) => {
+	return mockDb
+		.withArgs({
+			TableName: 'penaltyGroups',
+			IndexName: 'ByOffset',
+			Limit: limit,
+			KeyConditionExpression: '#Origin = :Origin and #Offset >= :Offset',
+			ExpressionAttributeNames: { '#Offset': 'Offset', '#Origin': 'Origin' },
+			ExpressionAttributeValues: { ':Offset': offset, ':Origin': 'APP' },
+		});
+};

--- a/src/services/penaltyGroups.unit.js
+++ b/src/services/penaltyGroups.unit.js
@@ -88,7 +88,7 @@ const whenDbWithLimitAndOffset = (mockDb, limit, offset) => {
 			TableName: 'penaltyGroups',
 			IndexName: 'ByOffset',
 			Limit: limit,
-			KeyConditionExpression: '#Origin = :Origin and #Offset >= :Offset',
+			KeyConditionExpression: '#Origin = :Origin and #Offset > :Offset',
 			ExpressionAttributeNames: { '#Offset': 'Offset', '#Origin': 'Origin' },
 			ExpressionAttributeValues: { ':Offset': offset, ':Origin': 'APP' },
 		});

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -97,6 +97,7 @@ describe('penaltyGroups', () => {
 					.end((err, res) => {
 						if (err) throw err;
 						expect(res.body.ID).toBe('46xu68x7wps');
+						expect(res.body.Origin).toEqual('APP');
 						expect(res.body.Timestamp).toBe(1532945465.234729);
 						expect(res.body.Offset).toBeCloseTo(Date.now() / 1000, 1);
 						expect(res.body.Location).toBe('Trowell Services');


### PR DESCRIPTION
* Force all submitted penalty groups to include an `Origin` field
* Add endpoint `GET /penaltyGroups` with a query parameter for the `Offset`
* Query new `ByOffset` index (`Origin` + `Offset`) for penalty groups with a later `Offset`