### PR TITLE
RSP-1335: Deletion of penalty groups

### DIFF
--- a/mock-data/fake-penalty-groups.json
+++ b/mock-data/fake-penalty-groups.json
@@ -9,6 +9,7 @@
     "TotalAmount": 130,
     "SiteCode": 3,
     "Origin": "APP",
+    "IsEnabled": true,
     "PenaltyDocumentIds": [
       "820500000877_FPN",
       "820500000878_FPN"

--- a/mock-data/fake-penalty-groups.json
+++ b/mock-data/fake-penalty-groups.json
@@ -9,7 +9,7 @@
     "TotalAmount": 130,
     "SiteCode": 3,
     "Origin": "APP",
-    "IsEnabled": true,
+    "Enabled": true,
     "PenaltyDocumentIds": [
       "820500000877_FPN",
       "820500000878_FPN"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7217,9 +7217,9 @@
       }
     },
     "rsp-validation": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/rsp-validation/-/rsp-validation-1.5.1.tgz",
-      "integrity": "sha512-M+h5aH4wA6OdG/i+yrk/Esjqe6KbVXmMpfMhgDf8Xbf3jRaBTJDMPUbSGCpIvvDtBvrhsI941KE8Ey2C5uXnFQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/rsp-validation/-/rsp-validation-1.5.3.tgz",
+      "integrity": "sha512-NsvD9s2sMFGZKQsL6VnOToKgReH0TfKWg8dXpvdk4nCRd/3EAMT3V5E2N+XXbu5Yo8ovIJuLk8Ea/NfCvQWj6w==",
       "requires": {
         "joi": "^13.1.2"
       },
@@ -7238,9 +7238,9 @@
           }
         },
         "joi": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-13.5.0.tgz",
-          "integrity": "sha512-brcQASga7Bo/czBjP+0lYFniQCuX927OFsmUmGz8Xre77PeUe0EOaXmVMFmb1GQgeVfsTa2w6mYulODKRXKpag==",
+          "version": "13.5.2",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.5.2.tgz",
+          "integrity": "sha512-3HrFXLC57iU5CzYth3cJRdYEo4/Dr+tXmCQ+BHyiTTKnKxJ9ICkI/WJGPwUUXj3dWA4tO2hwZO5oCdBNhAYuRg==",
           "requires": {
             "hoek": "5.x.x",
             "isemail": "3.x.x",

--- a/src/functions/deleteGroup.js
+++ b/src/functions/deleteGroup.js
@@ -1,0 +1,13 @@
+import { doc } from 'serverless-dynamodb-client';
+
+import PenaltyGroupService from '../services/penaltyGroups';
+
+const penaltyGroupService = new PenaltyGroupService(
+	doc,
+	process.env.DYNAMODB_PENALTY_DOC_TABLE,
+	process.env.DYNAMODB_PENALTY_GROUP_TABLE,
+);
+
+export default (event, context, callback) => {
+	penaltyGroupService.delete(event.pathParameters.id, callback);
+};

--- a/src/functions/deleteGroup.unit.js
+++ b/src/functions/deleteGroup.unit.js
@@ -1,0 +1,26 @@
+import sinon from 'sinon';
+
+import DeleteGroup from './deleteGroup';
+import PenaltyGroupService from '../services/penaltyGroups';
+
+describe('Delete group function', () => {
+	let penaltyGroupSvc;
+	let callbackSpy;
+	const event = { pathParameters: { id: 'abcdefghij1' } };
+
+	beforeEach(() => {
+		penaltyGroupSvc = sinon.stub(PenaltyGroupService.prototype, 'delete');
+		penaltyGroupSvc
+			.withArgs('abcdefghij1')
+			.resolves();
+		callbackSpy = sinon.spy();
+	});
+	afterEach(() => {
+		PenaltyGroupService.prototype.delete.restore();
+		callbackSpy.resetHistory();
+	});
+	it('should return the result of calling the penalty group service delete method', () => {
+		DeleteGroup(event, null, callbackSpy);
+		sinon.assert.calledWith(penaltyGroupSvc, 'abcdefghij1', callbackSpy);
+	});
+});

--- a/src/handler.js
+++ b/src/handler.js
@@ -7,6 +7,7 @@ import create from './functions/create';
 import createPenaltyGroup from './functions/createPenaltyGroup';
 import getPenaltyGroup from './functions/getPenaltyGroup';
 import remove from './functions/delete';
+import deleteGroup from './functions/deleteGroup';
 import updateMulti from './functions/updateMulti';
 import sites from './functions/sites';
 import stream from './functions/stream';
@@ -24,6 +25,7 @@ const handler = {
 	createPenaltyGroup,
 	getPenaltyGroup,
 	remove,
+	deleteGroup,
 	updateMulti,
 	sites,
 	stream,

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -122,6 +122,7 @@ export default class PenaltyGroup {
 		penGrp.Offset = Date.now() / 1000;
 		penGrp.PaymentStatus = 'UNPAID';
 		penGrp.Origin = penGrp.Origin || appOrigin;
+		penGrp.IsEnabled = true;
 		penGrp.Penalties.forEach((p) => {
 			p.inPenaltyGroup = true;
 			p.Hash = hashToken(p.ID, p.Value, p.Enabled);

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -74,6 +74,10 @@ export default class PenaltyGroup {
 		}
 	}
 
+	delete(penaltyGroupId) {
+
+	}
+
 	updatePenaltyGroupWithPayment(paymentInfo, callback) {
 		const getParams = {
 			TableName: this.penaltyGroupTableName,

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -43,6 +43,7 @@ describe('penaltyGroups', () => {
 						expect(res.body.Payments[0].Penalties[1].ID).toBe('820500000878_FPN');
 						expect(res.body.Payments[0].Penalties[1].Value).toBeDefined();
 						expect(res.body.PenaltyDocumentIds).toBeUndefined();
+						expect(res.body.IsEnabled).toBe(true);
 						done();
 					});
 			});
@@ -151,6 +152,7 @@ describe('penaltyGroups', () => {
 						expect(res.body.Penalties[0].inPenaltyGroup).toBe(true);
 						expect(res.body.Penalties[1].inPenaltyGroup).toBe(true);
 						expect(res.body.PenaltyGroupIds).toBeUndefined();
+						expect(res.body.IsEnabled).toBe(true);
 						done();
 					});
 			});

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -45,7 +45,7 @@ describe('penaltyGroups', () => {
 						expect(res.body.Payments[0].Penalties[1].ID).toBe('820500000878_FPN');
 						expect(res.body.Payments[0].Penalties[1].Value).toBeDefined();
 						expect(res.body.PenaltyDocumentIds).toBeUndefined();
-						expect(res.body.IsEnabled).toBe(true);
+						expect(res.body.Enabled).toBe(true);
 						done();
 					});
 			});
@@ -154,7 +154,7 @@ describe('penaltyGroups', () => {
 						expect(res.body.Penalties[0].inPenaltyGroup).toBe(true);
 						expect(res.body.Penalties[1].inPenaltyGroup).toBe(true);
 						expect(res.body.PenaltyGroupIds).toBeUndefined();
-						expect(res.body.IsEnabled).toBe(true);
+						expect(res.body.Enabled).toBe(true);
 						done();
 					});
 			});
@@ -176,7 +176,7 @@ describe('penaltyGroups', () => {
 
 			it('should mark the penalty group and all its documents as disabled and return 204', async () => {
 				await request
-					.delete(`/penaltyGroup/${testPenaltyGroupId}`)
+					.delete(`/${testPenaltyGroupId}`)
 					.set('Content-Type', 'application/json')
 					.set('Authorization', 'allow')
 					.expect('Content-Type', 'application/json')
@@ -299,17 +299,17 @@ async function assertPenaltyGroupDisabled(penaltyGroupId) {
 		},
 	}).promise();
 
-	expect(penaltyGroup.Enabled).toBe(false);
+	expect(penaltyGroup.Item.Enabled).toBe(false);
 }
 
 async function assertPenaltyDocumentsDisabled(documentIds) {
-	documentIds.forEach((id) => {
-		const document = docClient.get({
+	documentIds.forEach(async (id) => {
+		const document = await docClient.get({
 			TableName: 'penaltyDocuments',
 			Key: {
 				ID: id,
 			},
-		});
-		expect(document.Enabled).toBe(false);
+		}).promise();
+		expect(document.Item.Enabled).toBe(false);
 	});
 }


### PR DESCRIPTION
* Set `Enabled` flag to `true` for all penalty groups upon creation
* Add `DELETE /penaltyGroup/:id:` endpoint which marks penalty group and all its documents as disabled