### PR TITLE
RSP-1455/1456 - Facilitate single penalty search by vehicle reg

### DIFF
--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -163,6 +163,7 @@ export default class PenaltyGroup {
 		const penGrp = { ...body };
 		const { Timestamp, SiteCode, Penalties } = penGrp;
 		const penaltyGroupId = PenaltyGroup.generatePenaltyGroupId(Timestamp, SiteCode);
+		penGrp.VehicleRegistration = penGrp.VehicleRegistration.replace(/ /g, '').toUpperCase();
 		penGrp.ID = penaltyGroupId;
 		penGrp.TotalAmount = Penalties.reduce((total, pen) => pen.Value.penaltyAmount + total, 0);
 		penGrp.Offset = Date.now() / 1000;

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -172,6 +172,7 @@ export default class PenaltyGroup {
 		penGrp.Hash = hashToken(penaltyGroupId, penGrp, penGrp.Enabled);
 		penGrp.Penalties.forEach((p) => {
 			p.inPenaltyGroup = true;
+			p.penaltyGroupId = penaltyGroupId;
 			p.Hash = hashToken(p.ID, p.Value, p.Enabled);
 			p.Origin = p.Origin || appOrigin;
 			p.Offset = getUnixTime();

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -107,6 +107,7 @@ describe('penaltyGroups', () => {
 					SiteCode: -72,
 					Location: 'Trowell Services',
 					VehicleRegistration: '11 ABC',
+					Offset: 123,
 					Penalties: [
 						{
 							ID: 'p1',
@@ -168,6 +169,8 @@ describe('penaltyGroups', () => {
 						expect(res.body.Penalties).toHaveLength(2);
 						expect(res.body.Penalties[0].inPenaltyGroup).toBe(true);
 						expect(res.body.Penalties[1].inPenaltyGroup).toBe(true);
+						expect(res.body.Penalties[0].penaltyGroupId).toBe('46xu68x7wps');
+						expect(res.body.Penalties[1].penaltyGroupId).toBe('46xu68x7wps');
 						expect(res.body.PenaltyGroupIds).toBeUndefined();
 						expect(res.body.Enabled).toBe(true);
 						expect(res.body.Hash).toBeDefined();

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -106,7 +106,7 @@ describe('penaltyGroups', () => {
 					Timestamp: 1532945465.234729,
 					SiteCode: -72,
 					Location: 'Trowell Services',
-					VehicleRegistration: '11 ABC',
+					VehicleRegistration: '11 abc',
 					Offset: 123,
 					Penalties: [
 						{
@@ -163,7 +163,7 @@ describe('penaltyGroups', () => {
 						expect(res.body.Timestamp).toBe(1532945465.234729);
 						expect(res.body.Offset).toBeCloseTo(Date.now() / 1000, 1);
 						expect(res.body.Location).toBe('Trowell Services');
-						expect(res.body.VehicleRegistration).toBe('11 ABC');
+						expect(res.body.VehicleRegistration).toBe('11ABC');
 						expect(res.body.TotalAmount).toBe(230);
 						expect(res.body.PaymentStatus).toBe('UNPAID');
 						expect(res.body.Penalties).toHaveLength(2);


### PR DESCRIPTION
* RSP-1455: Add penalty group ID to group penalty documents
* RSP-1456: Trim + uppercase penalty group vehicle registration