### PR TITLE
Prevent 404 status on gets for cancelled penalty groups

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -437,6 +437,7 @@ resources:
                 - dynamodb:Scan
                 - dynamodb:Query
                 - dynamodb:GetItem
+                - dynamodb:BatchGetItem
                 - dynamodb:PutItem
                 - dynamodb:BatchWriteItem
                 - dynamodb:UpdateItem
@@ -448,9 +449,14 @@ resources:
               Resource: arn:aws:dynamodb:*:*:table/penaltyGroups
             - Effect: Allow
               Action:
+                - dynamodb:Query
+              Resource: arn:aws:dynamodb:*:*:table/penaltyDocuments/index/ByVehicleRegistration
+            - Effect: Allow
+              Action:
                 - dynamodb:Scan
                 - dynamodb:Query
                 - dynamodb:GetItem
+                - dynamodb:BatchGetItem
                 - dynamodb:PutItem
                 - dynamodb:BatchWriteItem
                 - dynamodb:UpdateItem
@@ -460,19 +466,5 @@ resources:
                 - dynamodb:GetShardIterator
                 - dynamodb:ListStreams
               Resource: arn:aws:dynamodb:*:*:table/penaltyGroups/index/ByOffset
-            - Effect: Allow
-              Action:
-                - dynamodb:Scan
-                - dynamodb:Query
-                - dynamodb:GetItem
-                - dynamodb:PutItem
-                - dynamodb:BatchWriteItem
-                - dynamodb:UpdateItem
-                - dynamodb:DeleteItem
-                - dynamodb:DescribeStream
-                - dynamodb:GetRecords
-                - dynamodb:GetShardIterator
-                - dynamodb:ListStreams
-              Resource: arn:aws:dynamodb:*:*:table/penaltyGroups/index/VehicleRegistration
         Roles:
           - Ref: IamRoleLambdaExecution

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -63,7 +63,7 @@ export default class PenaltyGroup {
 		try {
 			const penaltyGroup = await this._getPenaltyGroupById(penaltyGroupId);
 
-			if (!penaltyGroup || penaltyGroup.Enabled === false) {
+			if (!penaltyGroup) {
 				const msg = `Penalty Group ${penaltyGroupId} not found`;
 				return callback(null, createResponse({ statusCode: 404, body: { error: msg } }));
 			}

--- a/src/services/vehicleRegistrationSearch.js
+++ b/src/services/vehicleRegistrationSearch.js
@@ -38,12 +38,14 @@ export default class VehicleRegistrationSearch {
 						}));
 					})
 					.catch((err) => {
+						console.log(err);
 						return callback(null, createErrorResponse({ statusCode: 400, body: err }));
 					});
 			}
 			// Return 404 not found
 			return callback(null, createErrorResponse({ statusCode: 404, body: 'No penalties found' }));
 		} catch (err) {
+			console.log(err);
 			return callback(null, createErrorResponse({ statusCode: 400, body: err }));
 		}
 	}

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -53,12 +53,12 @@ describe('penaltyGroups', () => {
 						done();
 					});
 			});
-			it('should respond 404 if the penalty group is disabled', (done) => {
+			it('should respond 200 even when the penalty group is disabled', (done) => {
 				request
 					.get(`/${disabledGroupId}`)
 					.set('Content-Type', 'application/json')
 					.set('Authorization', 'allow')
-					.expect(404)
+					.expect(200)
 					.expect('Content-Type', 'application/json')
 					.end((err) => {
 						if (err) throw err;


### PR DESCRIPTION
* Access to cancelled penalty groups on public portal was previously
  (poorly) implemented by giving a 404 from document service when
  requesting the group details
* Internal portal needs access to the penalty group, even when it's
  cancelled
* Prevent the 404 on cancelled groups, push responsibility of access
  authorisation to the client