### PR TITLE
Enable multi-penalty cancellation + partial/complete recreation scenario

### DIFF
--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -49,7 +49,8 @@ export default class PenaltyGroup {
 
 		const newDocIds = payload.Penalties.map(p => p.ID);
 		const existingDocsWithIds = await this._getPenaltyDocumentsWithIds(newDocIds);
-		if (existingDocsWithIds.length !== 0) {
+		const allExistingDocsDisabled = existingDocsWithIds.every(p => p.Enabled === false);
+		if (existingDocsWithIds.length !== 0 && !allExistingDocsDisabled) {
 			const clashingIds = existingDocsWithIds.map(doc => doc.ID);
 			return { valid: false, message: `There were clashing IDs (${clashingIds.join(',')})` };
 		}

--- a/src/services/vehicleRegistrationSearch.js
+++ b/src/services/vehicleRegistrationSearch.js
@@ -38,12 +38,14 @@ export default class VehicleRegistrationSearch {
 						}));
 					})
 					.catch((err) => {
+						console.log(err);
 						return callback(null, createErrorResponse({ statusCode: 400, body: err }));
 					});
 			}
 			// Return 404 not found
 			return callback(null, createErrorResponse({ statusCode: 404, body: 'No penalties found' }));
 		} catch (err) {
+			console.log(err);
 			return callback(null, createErrorResponse({ statusCode: 400, body: err }));
 		}
 	}


### PR DESCRIPTION
* Penalty groups had validation enforcing that none of their constituent
  references already exist in dynamo. This was to prevent accidental
  overwrites.
* This constraint prevented a primary use-case, where a driver contests
  one of the fines in a penalty group, and operators cancel the whole
  group and recreate part of it with identical references
* On group creation, where reference clashes exists, allow the overwrite
  when all of the clashing references are cancelled