### PR TITLE
Ensure we update penalty document Offset when setting to paid

### DIFF
--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -329,6 +329,7 @@ export default class PenaltyGroup {
 	_createUpdatePenaltiesPutParameters(penalties, tableName, paymentStatus) {
 		const putRequests = penalties.map((p) => {
 			p.Value.paymentStatus = paymentStatus;
+			p.Offset = Date.now() / 1000;
 			return {
 				PutRequest: { Item: p },
 			};


### PR DESCRIPTION
* Failure to update Offset was causing an issue where the phone would
  not fetch updates to payment status on a penalty document
* This manifested as a group on the dashboard saying PAID, but the
  penalties within it still reading UNPAID