### PR TITLE
Prevent duplicate penalties from picking up payments from their conflict

### DIFF
--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -609,11 +609,7 @@ export default class PenaltyDocument {
 					}
 					resolve(createSimpleResponse({ statusCode: 200, body: updatedItem }));
 				}).catch((err) => {
-					updatedItem.Value.paymentStatus = savedPaymentStatus;
-					if (savedPaymentStatus === 'PAID') {
-						updatedItem.Value.paymentAuthCode = savedPaymentAuthCode;
-						updatedItem.Value.paymentDate = savedPaymentDate;
-					}
+					updatedItem.Value.paymentStatus = 'UNPAID';
 					resolve(createSimpleResponse({ statusCode: 400, body: updatedItem, error: err }));
 				});
 			} else {


### PR DESCRIPTION
* When creating a single penalty, the phone blocks creation if there is
  a reference clash with a penalty in the phone's DB (<3 days old)
* If the clash is with a reference >3 days old, the penalty is submitted
  and the API prevents the creation via a DynamoDB update condition
* In the event that the condition prevents creation of a duplicate,
  respond indicating that the penalty is UNPAID