### PR TITLE
Allow cancellation of penalty groups that are already partially paid

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -45,7 +45,7 @@ const fromConfiguration = configKey => () => {
 };
 
 const fromConfigurationWithDefault = (configKey, defaultValue) => () => {
-	return fromConfiguration(configKey) || defaultValue;
+	return fromConfiguration(configKey)() || defaultValue;
 };
 
 export default {

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -154,7 +154,7 @@ export default class PenaltyGroup {
 			.filter(doc => paidIds.includes(doc.ID));
 		amendedGroup.Offset = getUnixTime();
 		amendedGroup.PaymentStatus = 'PAID';
-		amendedGroup.TotalAmount = 	paidPenaltyDocuments
+		amendedGroup.TotalAmount = paidPenaltyDocuments
 			.reduce((sum, doc) => sum + doc.Value.penaltyAmount, 0);
 		amendedGroup.VehicleRegistration = paidPenaltyDocuments
 			.map(doc => doc.Value.vehicleDetails.regNo)

--- a/src/services/penaltyGroups.js
+++ b/src/services/penaltyGroups.js
@@ -143,8 +143,9 @@ export default class PenaltyGroup {
 	async _spliceUnpaidPenaltiesFromGroup(group, penaltyDocs) {
 		const { paidIds, unpaidIds } = this._groupPenaltyIdsByPaymentStatus(penaltyDocs);
 		const amendedGroup = this._amendGroupRemovingUnpaidPenalties(group, penaltyDocs, paidIds);
-		await this._persistPenaltyGroup(amendedGroup);
-		await this._destroyPenaltiesWithIds(unpaidIds);
+		const groupAmendmentPromise = this._persistPenaltyGroup(amendedGroup);
+		const documentDestroyPromise = this._destroyPenaltiesWithIds(unpaidIds);
+		await Promise.all([groupAmendmentPromise, documentDestroyPromise]);
 	}
 
 	_amendGroupRemovingUnpaidPenalties(penaltyGroup, penaltyDocuments, paidIds) {

--- a/src/test/penaltyGroups.serviceInt.js
+++ b/src/test/penaltyGroups.serviceInt.js
@@ -385,7 +385,7 @@ async function insertDeletionTestPartPaidPenaltyGroup() {
 	const groupVehicleReg = '11AAA,11AAB,11AAC';
 	const allDocIds = [paidIm.id, ...unpaidFpns.map(fpn => fpn.id)];
 	const documentPutRequests = [
-		documentPutRequest(paidIm.id, 'PAID', paidIm.reg),
+		documentPutRequest(paidIm.id, 'PAID', paidIm.reg, paidIm.amount),
 		...unpaidFpns.map(fpn => documentPutRequest(fpn.id, 'UNPAID', fpn.reg, fpn.amount)),
 	];
 	const params = {


### PR DESCRIPTION
* Identify partially paid cancellation scenario by finding whether any of the documents in the group are already paid
* Find the unpaid penalties and delete them, both from the group and completely remove the document from DynamoDB
* Update the Hash, Offset, VehicleRegistration, TotalAmount and PaymentStatus on the group to make it consistent