### PR TITLE
RSP-1664: Check + update group payment status when reversing single penalty status

### DIFF
--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -106,9 +106,9 @@ export default class PenaltyDocument {
 			};
 
 			const docPutPromise = this.db.put(docPutParams).promise();
-			const tryUpdatePenaltyGroupPromise = this._tryUpdatePenaltyGroupPaymentStatus(doc, newStatus);
+			const penGrpUpdatePromise = this._tryUpdatePenaltyGroupToUnpaidStatus(doc, newStatus);
 
-			Promise.all([docPutPromise, tryUpdatePenaltyGroupPromise]).then(() => {
+			Promise.all([docPutPromise, penGrpUpdatePromise]).then(() => {
 				callback(null, createResponse({ statusCode: 200, body: doc }));
 			}).catch((err) => {
 				const returnResponse = createErrorResponse({ statusCode: 400, err });
@@ -120,8 +120,11 @@ export default class PenaltyDocument {
 		});
 	}
 
-	async _tryUpdatePenaltyGroupPaymentStatus(doc, paymentStatus) {
-		if ((!doc.inPenaltyGroup && !doc.Value.inPenaltyGroup) || !doc.penaltyGroupId) {
+	async _tryUpdatePenaltyGroupToUnpaidStatus(doc, paymentStatus) {
+		if (
+			(!doc.inPenaltyGroup && !doc.Value.inPenaltyGroup)
+			|| !doc.penaltyGroupId
+			|| paymentStatus !== 'UNPAID') {
 			return Promise.resolve();
 		}
 

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -88,31 +88,60 @@ export default class PenaltyDocument {
 				ID: paymentInfo.id,
 			},
 		};
-		const dbGet = this.db.get(getParams).promise();
+		const docGet = this.db.get(getParams).promise();
 
-		dbGet.then((data) => {
-			data.Item.Value.paymentStatus = paymentInfo.paymentStatus;
-			data.Item.Hash = hashToken(paymentInfo.id, data.Item.Value, data.Item.Enabled);
-			data.Item.Offset = getUnixTime();
-			const putParams = {
+		docGet.then((docContainer) => {
+			const doc = docContainer.Item;
+			const newStatus = paymentInfo.paymentStatus;
+			doc.Value.paymentStatus = newStatus;
+			doc.Hash = hashToken(paymentInfo.id, doc.Value, doc.Enabled);
+			doc.Offset = getUnixTime();
+			const docPutParams = {
 				TableName: this.penaltyDocTableName,
-				Item: data.Item,
+				Item: doc,
 				ConditionExpression: 'attribute_exists(#ID)',
 				ExpressionAttributeNames: {
 					'#ID': 'ID',
 				},
 			};
 
-			const dbPut = this.db.put(putParams).promise();
-			dbPut.then(() => {
-				callback(null, createResponse({ statusCode: 200, body: data.Item }));
+			const docPutPromise = this.db.put(docPutParams).promise();
+			const tryUpdatePenaltyGroupPromise = this._tryUpdatePenaltyGroupPaymentStatus(doc, newStatus);
+
+			Promise.all([docPutPromise, tryUpdatePenaltyGroupPromise]).then(() => {
+				callback(null, createResponse({ statusCode: 200, body: doc }));
 			}).catch((err) => {
 				const returnResponse = createErrorResponse({ statusCode: 400, err });
 				callback(null, returnResponse);
 			});
 		}).catch((err) => {
+			console.log(err);
 			callback(null, createErrorResponse({ statusCode: 400, body: err }));
 		});
+	}
+
+	async _tryUpdatePenaltyGroupPaymentStatus(doc, paymentStatus) {
+		if ((!doc.inPenaltyGroup && !doc.Value.inPenaltyGroup) || !doc.penaltyGroupId) {
+			return Promise.resolve();
+		}
+
+		const penaltyGroupTable = config.dynamodbPenaltyGroupTable();
+		const getGroupParams = {
+			TableName: penaltyGroupTable,
+			Key: { ID: doc.penaltyGroupId },
+		};
+		const penaltyGroupContainer = await this.db.get(getGroupParams).promise();
+		const penaltyGroup = penaltyGroupContainer.Item;
+		if (penaltyGroup.PaymentStatus !== paymentStatus) {
+			penaltyGroup.PaymentStatus = paymentStatus;
+			penaltyGroup.Offset = getUnixTime();
+			const putGroupParams = {
+				TableName: penaltyGroupTable,
+				Item: penaltyGroup,
+			};
+			return this.db.put(putGroupParams).promise();
+		}
+		return Promise.resolve();
 	}
 
 	// put


### PR DESCRIPTION
* Check the document we're updating the payment status of
* If it's in a penalty group and we're specifically making that document unpaid, it's penalty group should also become unpaid