### PR TITLE
WIP RSP-1664: Reverse group payment set unpaid

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -73,9 +73,25 @@ functions:
   updateUponPaymentDelete:
     handler: handler.updateUponPaymentDelete
     memorySize: 128
+    events:
+      -
+        http:
+          path: documents/updateUponPaymentDelete
+          method: put
+          authorizer: aws_iam
+          timeout: 12
+          cors: true
   updateMultipleUponPaymentDelete:
     handler: handler.updateMultipleUponPaymentDelete
     memorySize: 128
+    events:
+      -
+        http:
+          path: documents/updateMultipleUponPaymentDelete
+          method: put
+          authorizer: aws_iam
+          timeout: 12
+          cors: true
   sites:
     handler: handler.sites
     memorySize: 128

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -73,6 +73,9 @@ functions:
   updateUponPaymentDelete:
     handler: handler.updateUponPaymentDelete
     memorySize: 128
+  updateMultipleUponPaymentDelete:
+    handler: handler.updateMultipleUponPaymentDelete
+    memorySize: 128
   sites:
     handler: handler.sites
     memorySize: 128

--- a/src/functions/updateMultipleUponPaymentDelete.js
+++ b/src/functions/updateMultipleUponPaymentDelete.js
@@ -29,11 +29,10 @@ export default async (event, context, callback) => {
 	console.log(event);
 
 	const paymentInfo = {
-		id: event.body.id,
-		paymentStatus: event.body.paymentStatus,
+		penaltyDocumentIds: event.body.penaltyDocuments,
 	};
 
 	console.log(JSON.stringify(paymentInfo, null, 2));
 	// id body document
-	penaltyDocuments.updateDocumentUponPaymentDelete(paymentInfo, callback);
+	penaltyDocuments.updateDocumentsUponPaymentDelete(paymentInfo, callback);
 };

--- a/src/functions/updateMultipleUponPaymentDelete.js
+++ b/src/functions/updateMultipleUponPaymentDelete.js
@@ -26,13 +26,18 @@ export default async (event, context, callback) => {
 		);
 	}
 
-	console.log(event);
+	let { body } = event;
+
+	if (typeof body === 'string') {
+		// body is a string if invoked via http request rather than directly.
+		body = JSON.parse(event.body);
+	}
 
 	const paymentInfo = {
-		penaltyDocumentIds: event.body.penaltyDocuments,
+		penaltyDocumentIds: body.penaltyDocumentIds,
 	};
 
 	console.log(JSON.stringify(paymentInfo, null, 2));
-	// id body document
-	penaltyDocuments.updateDocumentsUponPaymentDelete(paymentInfo, callback);
+
+	penaltyDocuments.updateMultipleUponPaymentDelete(paymentInfo, callback);
 };

--- a/src/functions/updatePenaltyGroupWithPayment.unit.js
+++ b/src/functions/updatePenaltyGroupWithPayment.unit.js
@@ -1,0 +1,30 @@
+import sinon from 'sinon';
+
+import updatePenaltyGroupWithPayment from './updatePenaltyGroupWithPayment';
+import PenaltyGroupSvc from '../services/penaltyGroups';
+
+const TEST_ID = 'abc123';
+const PAYMENT_STATUS = 'PAID';
+const PENALTY_TYPE = 'test';
+
+
+describe('updatePenaltyGroupsWithPayment', () => {
+    let penaltyGroupSvc;
+    let callbackSpy;
+    const event = { body: { id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE } };
+
+    beforeEach(() => {
+        penaltyGroupSvc = sinon.stub(PenaltyGroupSvc.prototype, 'updatePenaltyGroupWithPayment')
+        penaltyGroupSvc.withArgs(event).resolves();
+        callbackSpy = sinon.spy();
+    });
+    afterEach(() => {
+        // Restore the function mocked by sinon.
+        PenaltyGroupSvc.prototype.updatePenaltyGroupWithPayment.restore();
+        callbackSpy.resetHistory();
+    });
+    it('should update the penalty groups with payment', async () => {
+        await updatePenaltyGroupWithPayment(event, null, callbackSpy);
+        sinon.assert.calledWith(penaltyGroupSvc, sinon.match({ id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE }));
+    });
+});

--- a/src/functions/updatePenaltyGroupWithPayment.unit.js
+++ b/src/functions/updatePenaltyGroupWithPayment.unit.js
@@ -9,22 +9,24 @@ const PENALTY_TYPE = 'test';
 
 
 describe('updatePenaltyGroupsWithPayment', () => {
-    let penaltyGroupSvc;
-    let callbackSpy;
-    const event = { body: { id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE } };
+	let penaltyGroupSvc;
+	let callbackSpy;
+	const event = { body: { id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE } };
 
-    beforeEach(() => {
-        penaltyGroupSvc = sinon.stub(PenaltyGroupSvc.prototype, 'updatePenaltyGroupWithPayment')
-        penaltyGroupSvc.withArgs(event).resolves();
-        callbackSpy = sinon.spy();
-    });
-    afterEach(() => {
-        // Restore the function mocked by sinon.
-        PenaltyGroupSvc.prototype.updatePenaltyGroupWithPayment.restore();
-        callbackSpy.resetHistory();
-    });
-    it('should update the penalty groups with payment', async () => {
-        await updatePenaltyGroupWithPayment(event, null, callbackSpy);
-        sinon.assert.calledWith(penaltyGroupSvc, sinon.match({ id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE }));
-    });
+	beforeEach(() => {
+		penaltyGroupSvc = sinon.stub(PenaltyGroupSvc.prototype, 'updatePenaltyGroupWithPayment');
+		penaltyGroupSvc.withArgs(event).resolves();
+		callbackSpy = sinon.spy();
+	});
+	afterEach(() => {
+		// Restore the function mocked by sinon.
+		PenaltyGroupSvc.prototype.updatePenaltyGroupWithPayment.restore();
+		callbackSpy.resetHistory();
+	});
+	it('should update the penalty groups with payment', async () => {
+		await updatePenaltyGroupWithPayment(event, null, callbackSpy);
+		sinon.assert.calledWith(penaltyGroupSvc, sinon.match({
+			id: TEST_ID, paymentStatus: PAYMENT_STATUS, penaltyType: PENALTY_TYPE,
+		}));
+	});
 });

--- a/src/functions/updateUponPaymentDelete.js
+++ b/src/functions/updateUponPaymentDelete.js
@@ -1,9 +1,14 @@
+// @ts-check
 /* eslint-env es6 */
 import 'babel-polyfill';
 import { doc } from 'serverless-dynamodb-client';
 import PenaltyDocument from '../services/penaltyDocuments';
 import config from '../config';
 
+/**
+ * Penalty documents service
+ * @type PenaltyDocument
+ */
 let penaltyDocuments;
 export default async (event, context, callback) => {
 	if (!penaltyDocuments) {
@@ -21,12 +26,13 @@ export default async (event, context, callback) => {
 		);
 	}
 
+	console.log(event);
+
 	const paymentInfo = {
-		id: event.body.id,
-		paymentStatus: event.body.paymentStatus,
+		penaltyDocuments: event.body.penaltyDocuments,
 	};
 
 	console.log(JSON.stringify(paymentInfo, null, 2));
 	// id body document
-	penaltyDocuments.updateDocumentUponPaymentDelete(paymentInfo, callback);
+	penaltyDocuments.updateDocumentsUponPaymentDelete(paymentInfo, callback);
 };

--- a/src/functions/updateUponPaymentDelete.js
+++ b/src/functions/updateUponPaymentDelete.js
@@ -26,11 +26,16 @@ export default async (event, context, callback) => {
 		);
 	}
 
-	console.log(event);
+	let { body } = event;
+
+	if (typeof body === 'string') {
+		// body is a string if invoked via http request rather than directly.
+		body = JSON.parse(event.body);
+	}
 
 	const paymentInfo = {
-		id: event.body.id,
-		paymentStatus: event.body.paymentStatus,
+		id: body.id,
+		paymentStatus: body.paymentStatus,
 	};
 
 	console.log(JSON.stringify(paymentInfo, null, 2));

--- a/src/functions/updateUponPaymentDelete.js
+++ b/src/functions/updateUponPaymentDelete.js
@@ -29,7 +29,7 @@ export default async (event, context, callback) => {
 	console.log(event);
 
 	const paymentInfo = {
-		penaltyDocuments: event.body.penaltyDocuments,
+		penaltyDocumentIds: event.body.penaltyDocuments,
 	};
 
 	console.log(JSON.stringify(paymentInfo, null, 2));

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,3 +1,4 @@
+// @ts-check
 import 'babel-polyfill';
 
 import list from './functions/list';
@@ -12,6 +13,7 @@ import updateMulti from './functions/updateMulti';
 import sites from './functions/sites';
 import updateWithPayment from './functions/updateWithPayment';
 import updateUponPaymentDelete from './functions/updateUponPaymentDelete';
+import updateMultipleUponPaymentDelete from './functions/updateMultipleUponPaymentDelete';
 import getDocumentByToken from './functions/getDocumentByToken';
 import updatePenaltyGroupWithPayment from './functions/updatePenaltyGroupWithPayment';
 import searchByVehicleRegistration from './functions/searchByVehicleRegistration';
@@ -28,6 +30,7 @@ const handler = {
 	deleteGroup,
 	updateMulti,
 	sites,
+	updateMultipleUponPaymentDelete,
 	updateWithPayment,
 	updateUponPaymentDelete,
 	updatePenaltyGroupWithPayment,

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -110,8 +110,7 @@ export default class PenaltyDocument {
 			const penGrpUpdatePromise = this._tryUpdatePenaltyGroupToUnpaidStatus(doc, newStatus);
 
 			try {
-				await docPutPromise;
-				await penGrpUpdatePromise;
+				await Promise.all([docPutPromise, penGrpUpdatePromise]);
 			} catch (innerError) {
 				const returnResponse = createErrorResponse({ statusCode: 400, innerError });
 				callback(null, returnResponse);

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -95,6 +95,40 @@ export default class PenaltyDocument {
 		return JSON.stringify(obj) === JSON.stringify({});
 	}
 
+	updateDocumentUponPaymentDelete(paymentInfo, callback) {
+		const getParams = {
+			TableName: this.penaltyDocTableName,
+			Key: {
+				ID: paymentInfo.id,
+			},
+		};
+		const dbGet = this.db.get(getParams).promise();
+
+		dbGet.then((data) => {
+			data.Item.Value.paymentStatus = paymentInfo.paymentStatus;
+			data.Item.Hash = hashToken(paymentInfo.id, data.Item.Value, data.Item.Enabled);
+			data.Item.Offset = getUnixTime();
+			const putParams = {
+				TableName: this.penaltyDocTableName,
+				Item: data.Item,
+				ConditionExpression: 'attribute_exists(#ID)',
+				ExpressionAttributeNames: {
+					'#ID': 'ID',
+				},
+			};
+
+			const dbPut = this.db.put(putParams).promise();
+			dbPut.then(() => {
+				callback(null, createResponse({ statusCode: 200, body: data.Item }));
+			}).catch((err) => {
+				const returnResponse = createErrorResponse({ statusCode: 400, err });
+				callback(null, returnResponse);
+			});
+		}).catch((err) => {
+			callback(null, createErrorResponse({ statusCode: 400, err }));
+		});
+	}
+
 	/**
 	 * Update the penalty document and its parent group with paymentInfo.
 	 * @param {{penaltyDocumentIds: Array<string>}} paymentInfo The new

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -81,6 +81,12 @@ export default class PenaltyDocument {
 		return JSON.stringify(obj) === JSON.stringify({});
 	}
 
+	/**
+	 * Update the penalty document and its parent group with paymentInfo.
+	 * @param {*} paymentInfo The new payment info.
+	 * @param {(_, response) => void} callback Callback returning a status code
+	 * and the new document or an error.
+	 */
 	async updateDocumentUponPaymentDelete(paymentInfo, callback) {
 		const getParams = {
 			TableName: this.penaltyDocTableName,
@@ -122,6 +128,12 @@ export default class PenaltyDocument {
 		}
 	}
 
+	/**
+	 * Sets the group status to UNPAID and updates its timestamp if currently set to PAID.
+	 * @param {*} doc The penalty document for which the corresponding group is updated.
+	 * @param {*} paymentStatus The new payment status. If set to anything other than 'UNPAID',
+	 * the method will resolve immediately.
+	 */
 	async _tryUpdatePenaltyGroupToUnpaidStatus(doc, paymentStatus) {
 		if (
 			(!doc.inPenaltyGroup && !doc.Value.inPenaltyGroup)

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -102,29 +102,40 @@ export default class PenaltyDocument {
 				ID: paymentInfo.id,
 			},
 		};
-		const dbGet = this.db.get(getParams).promise();
+		const docGet = this.db.get(getParams).promise();
 
-		dbGet.then((data) => {
-			data.Item.Value.paymentStatus = paymentInfo.paymentStatus;
-			data.Item.Hash = hashToken(paymentInfo.id, data.Item.Value, data.Item.Enabled);
-			data.Item.Offset = getUnixTime();
-			const putParams = {
+		docGet.then((docContainer) => {
+			const doc = docContainer.Item;
+			const newStatus = paymentInfo.paymentStatus;
+			doc.Value.paymentStatus = newStatus;
+			doc.Hash = hashToken(paymentInfo.id, doc.Value, doc.Enabled);
+			doc.Offset = getUnixTime();
+			const docPutParams = {
 				TableName: this.penaltyDocTableName,
-				Item: data.Item,
+				Item: doc,
 				ConditionExpression: 'attribute_exists(#ID)',
 				ExpressionAttributeNames: {
 					'#ID': 'ID',
 				},
 			};
 
-			const dbPut = this.db.put(putParams).promise();
-			dbPut.then(() => {
-				callback(null, createResponse({ statusCode: 200, body: data.Item }));
+			const docPutPromise = this.db.put(docPutParams).promise();
+			let penGrpUpdatePromise;
+			if ((doc.Value.inPenaltyGroup) && (doc.penaltyGroupId && newStatus === 'UNPAID')) {
+				penGrpUpdatePromise = this._tryUpdatePenaltyGroupToUnpaidStatus(
+					doc.penaltyGroupId,
+					newStatus,
+				);
+			}
+
+			Promise.all([docPutPromise, penGrpUpdatePromise]).then(() => {
+				callback(null, createResponse({ statusCode: 200, body: doc }));
 			}).catch((err) => {
 				const returnResponse = createErrorResponse({ statusCode: 400, err });
 				callback(null, returnResponse);
 			});
 		}).catch((err) => {
+			console.log(err);
 			callback(null, createErrorResponse({ statusCode: 400, err }));
 		});
 	}
@@ -215,13 +226,6 @@ export default class PenaltyDocument {
 	 * the method will resolve immediately.
 	 */
 	async _tryUpdatePenaltyGroupToUnpaidStatus(penaltyGroupId, paymentStatus) {
-		// if (
-		// 	(!doc.inPenaltyGroup && !doc.Value.inPenaltyGroup)
-		// 	|| !doc.penaltyGroupId
-		// 	|| paymentStatus !== 'UNPAID') {
-		// 	return Promise.resolve();
-		// }
-
 		const penaltyGroupTable = config.dynamodbPenaltyGroupTable();
 		const getGroupParams = {
 			TableName: penaltyGroupTable,

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint class-methods-use-this: "off" */
 /* eslint-env es6 */
 import { SNS, S3, Lambda } from 'aws-sdk';
@@ -70,10 +71,10 @@ export default class PenaltyDocument {
 					}
 					callback(null, createResponse({ statusCode: 200, body: data.Item }));
 				}).catch((err) => {
-					callback(null, createErrorResponse({ statusCode: 400, body: err }));
+					callback(null, createErrorResponse({ statusCode: 400, err }));
 				});
 		}).catch((err) => {
-			callback(null, createErrorResponse({ statusCode: 400, body: err }));
+			callback(null, createErrorResponse({ statusCode: 400, err }));
 		});
 	}
 
@@ -83,7 +84,7 @@ export default class PenaltyDocument {
 
 	/**
 	 * Update the penalty document and its parent group with paymentInfo.
-	 * @param {*} paymentInfo The new payment info.
+	 * @param {{id: string, paymentStatus: string}} paymentInfo The new payment info.
 	 * @param {(_, response) => void} callback Callback returning a status code
 	 * and the new document or an error.
 	 */
@@ -118,13 +119,13 @@ export default class PenaltyDocument {
 			try {
 				await Promise.all([docPutPromise, penGrpUpdatePromise]);
 			} catch (innerError) {
-				const returnResponse = createErrorResponse({ statusCode: 400, innerError });
+				const returnResponse = createErrorResponse({ statusCode: 400, err: innerError });
 				callback(null, returnResponse);
 			}
 
 			callback(null, createResponse({ statusCode: 200, body: doc }));
 		} catch (err) {
-			callback(null, createErrorResponse({ statusCode: 400, body: err }));
+			callback(null, createErrorResponse({ statusCode: 400, err }));
 		}
 	}
 
@@ -225,7 +226,7 @@ export default class PenaltyDocument {
 				callback(null, returnResponse);
 			});
 		}).catch((err) => {
-			callback(null, createErrorResponse({ statusCode: 400, body: err }));
+			callback(null, createErrorResponse({ statusCode: 400, err }));
 		});
 	}
 
@@ -406,13 +407,13 @@ export default class PenaltyDocument {
 						dbUpdate.then(() => {
 							callback(null, createResponse({ statusCode: 200, body: deletedItem }));
 						}).catch((err) => {
-							const errResponse = createErrorResponse({ statusCode: 400, body: err });
+							const errResponse = createErrorResponse({ statusCode: 400, err });
 							callback(null, errResponse);
 						});
 					}
 				}
 			}).catch((err) => {
-				callback(null, createErrorResponse({ statusCode: 400, body: err }));
+				callback(null, createErrorResponse({ statusCode: 400, err }));
 			});
 	}
 
@@ -492,7 +493,7 @@ export default class PenaltyDocument {
 			if (error) {
 				console.log('Token service returned an error');
 				console.log(error.message);
-				callback(null, createErrorResponse({ statusCode: 400, error }));
+				callback(null, createErrorResponse({ statusCode: 400, err: error }));
 			} else if (data.Payload) {
 				try {
 					const parsedPayload = JSON.parse(data.Payload);
@@ -534,7 +535,7 @@ export default class PenaltyDocument {
 								})
 								.catch((e) => {
 									console.log(`Error getting payment info: ${e}`);
-									callback(null, createErrorResponse({ statusCode: 400, e }));
+									callback(null, createErrorResponse({ statusCode: 400, err: e }));
 								});
 						} else if (res.statusCode === 200) {
 							callback(null, createResponse({ statusCode: 200, body: JSON.parse(res.body) }));
@@ -550,7 +551,7 @@ export default class PenaltyDocument {
 					});
 				} catch (e) {
 					console.log(`top level catch getting doc by token: ${e}`);
-					callback(null, createErrorResponse({ statusCode: 400, e }));
+					callback(null, createErrorResponse({ statusCode: 400, err: e }));
 				}
 				return;
 			}

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -1,20 +1,25 @@
-
+// @ts-check
 import expect from 'expect';
 import { doc } from 'serverless-dynamodb-client';
 import sinon from 'sinon';
 import PenaltyDocumentsService from './penaltyDocuments';
 import hashToken from '../utils/hash';
 import getUnixTime from '../utils/time';
+// @ts-ignore
 import mockPenaltyGroupsData from '../../mock-data/fake-penalty-groups.json';
+// @ts-ignore
 import mockPenaltiesData from '../../mock-data/fake-penalty-notice.json';
 
 
 describe('PenaltyDocuments service', () => {
+	/**
+	 * @type PenaltyDocumentsService
+	 */
 	let penaltyDocumentsService;
 	let callbackSpy;
 
 	beforeEach(() => {
-		penaltyDocumentsService = new PenaltyDocumentsService(doc, 'penaltyDocuments', '', '', '', '', '', '', '');
+		penaltyDocumentsService = new PenaltyDocumentsService(doc, 'penaltyDocuments', '', '', '', '', '', 3, '');
 		callbackSpy = sinon.spy();
 		sinon.stub(doc, 'put')
 			.returns({
@@ -22,7 +27,9 @@ describe('PenaltyDocuments service', () => {
 			});
 	});
 	afterEach(() => {
+		// @ts-ignore
 		doc.get.restore();
+		// @ts-ignore
 		doc.put.restore();
 		callbackSpy.resetHistory();
 	});
@@ -46,7 +53,8 @@ describe('PenaltyDocuments service', () => {
 			});
 			const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
 			sinon.stub(penaltyDocumentsService, '_tryUpdatePenaltyGroupToUnpaidStatus').callsFake(() => mockPenaltyGroup);
-			await penaltyDocumentsService.updateDocumentUponPaymentDelete({ id: 'abcdefg123', paymentStatus: 'UNPAID' }, callbackSpy);
+			sinon.stub(penaltyDocumentsService, '_updateDocumentsToUnpaidStatus').callsFake(() => ['abcdefg123']);
+			await penaltyDocumentsService.updateDocumentsUponPaymentDelete({ penaltyDocumentIds: ['abcdefg123'] }, callbackSpy);
 			sinon.assert.calledWith(callbackSpy, null, sinon.match({
 				statusCode: 200,
 			}));

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -1,7 +1,12 @@
+
+import expect from 'expect';
 import { doc } from 'serverless-dynamodb-client';
 import sinon from 'sinon';
 import PenaltyDocumentsService from './penaltyDocuments';
+import hashToken from '../utils/hash';
+import getUnixTime from '../utils/time';
 import mockPenaltyGroupsData from '../../mock-data/fake-penalty-groups.json';
+import mockPenaltiesData from '../../mock-data/fake-penalty-notice.json';
 
 
 describe('PenaltyDocuments service', () => {
@@ -11,6 +16,10 @@ describe('PenaltyDocuments service', () => {
 	beforeEach(() => {
 		penaltyDocumentsService = new PenaltyDocumentsService(doc, 'penaltyDocuments', '', '', '', '', '', '', '');
 		callbackSpy = sinon.spy();
+		sinon.stub(doc, 'put')
+			.returns({
+				promise: () => Promise.resolve('put resolved'),
+			});
 	});
 	afterEach(() => {
 		doc.get.restore();
@@ -18,32 +27,52 @@ describe('PenaltyDocuments service', () => {
 		callbackSpy.resetHistory();
 	});
 
-	it('updateDocumentUponPaymentDelete', async () => {
-		sinon.stub(doc, 'put')
-			.returns({
-				promise: () => Promise.resolve('put resolved'),
+	describe('updateDocumentUponPaymentDelete', () => {
+		it('calls back with OK status', async () => {
+			/**
+			 * Mock for db.get in updateDocumentUponPaymentDelete.
+			 * _tryUpdatePenaltyGroupToUnpaidStatus is stubbed so will not be called.
+			 */
+			sinon.stub(doc, 'get').returns({
+				promise: () => Promise.resolve({
+					Item: {
+						Value: {},
+						ID: 'abc123def45',
+						Enabled: true,
+						penaltyGroupId: 'groupIdPen',
+						inPenaltyGroup: true,
+					},
+				}),
 			});
-		/**
-		 * Mock for db.get in updateDocumentUponPaymentDelete.
-		 * _tryUpdatePenaltyGroupToUnpaidStatus is stubbed so will not be called.
-		 */
-		sinon.stub(doc, 'get').returns({
-			promise: () => Promise.resolve({
-				Item: {
-					Value: {},
-					ID: 'abc123def45',
-					Enabled: true,
-					penaltyGroupId: 'groupIdPen',
-					PenaltyDocumentIds: ['doc1', 'doc2'],
-					inPenaltyGroup: true,
-				},
-			}),
+			const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
+			sinon.stub(penaltyDocumentsService, '_tryUpdatePenaltyGroupToUnpaidStatus').callsFake(() => mockPenaltyGroup);
+			await penaltyDocumentsService.updateDocumentUponPaymentDelete({ id: 'abcdefg123', paymentStatus: 'UNPAID' }, callbackSpy);
+			sinon.assert.calledWith(callbackSpy, null, sinon.match({
+				statusCode: 200,
+			}));
 		});
-		const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
-		sinon.stub(penaltyDocumentsService, '_tryUpdatePenaltyGroupToUnpaidStatus').callsFake(() => mockPenaltyGroup);
-		await penaltyDocumentsService.updateDocumentUponPaymentDelete({ id: 'abcdefg123', paymentStatus: 'UNPAID' }, callbackSpy);
-		sinon.assert.calledWith(callbackSpy, null, sinon.match({
-			statusCode: 200,
-		}));
+	});
+
+	describe('_tryUpdatePenaltyGroupToUnpaidStatus', () => {
+		it("doesn't update when the payment status is paid", async () => {
+			// return mock penalty group container from db.get.
+			const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
+			const mockPenaltyDocument = mockPenaltiesData.find((penalty) => {
+				return penalty.penaltyGroupId === mockPenaltyGroup.ID;
+			});
+			sinon.stub(doc, 'get').returns({
+				promise: () => Promise.resolve({
+					Item: mockPenaltyGroup,
+				}),
+			});
+
+			mockPenaltyDocument.Value.paymentStatus = 'UNPAID';
+			mockPenaltyDocument.Hash = hashToken('46xu68x7o6b', mockPenaltyDocument.Value, mockPenaltyDocument.Enabled);
+			mockPenaltyDocument.Offset = getUnixTime();
+
+			// eslint-disable-next-line no-underscore-dangle
+			const promiseResponse = await penaltyDocumentsService._tryUpdatePenaltyGroupToUnpaidStatus(mockPenaltyDocument, 'PAID');
+			expect(promiseResponse).toBeUndefined();
+		});
 	});
 });

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -1,13 +1,10 @@
-// @ts-check
 import expect from 'expect';
 import { doc } from 'serverless-dynamodb-client';
 import sinon from 'sinon';
 import PenaltyDocumentsService from './penaltyDocuments';
 import hashToken from '../utils/hash';
 import getUnixTime from '../utils/time';
-// @ts-ignore
 import mockPenaltyGroupsData from '../../mock-data/fake-penalty-groups.json';
-// @ts-ignore
 import mockPenaltiesData from '../../mock-data/fake-penalty-notice.json';
 
 

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -34,7 +34,7 @@ describe('PenaltyDocuments service', () => {
 		callbackSpy.resetHistory();
 	});
 
-	describe('updateDocumentUponPaymentDelete', () => {
+	describe('updateDocumentsUponPaymentDelete', () => {
 		it('calls back with OK status', async () => {
 			/**
 			 * Mock for db.get in updateDocumentUponPaymentDelete.

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -51,7 +51,7 @@ describe('PenaltyDocuments service', () => {
 			const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
 			sinon.stub(penaltyDocumentsService, '_tryUpdatePenaltyGroupToUnpaidStatus').callsFake(() => mockPenaltyGroup);
 			sinon.stub(penaltyDocumentsService, '_updateDocumentsToUnpaidStatus').callsFake(() => ['abcdefg123']);
-			await penaltyDocumentsService.updateDocumentsUponPaymentDelete({ penaltyDocumentIds: ['abcdefg123'] }, callbackSpy);
+			await penaltyDocumentsService.updateMultipleUponPaymentDelete({ penaltyDocumentIds: ['abcdefg123'] }, callbackSpy);
 			sinon.assert.calledWith(callbackSpy, null, sinon.match({
 				statusCode: 200,
 			}));

--- a/src/services/penaltyDocuments.unit.js
+++ b/src/services/penaltyDocuments.unit.js
@@ -1,0 +1,49 @@
+import { doc } from 'serverless-dynamodb-client';
+import sinon from 'sinon';
+import PenaltyDocumentsService from './penaltyDocuments';
+import mockPenaltyGroupsData from '../../mock-data/fake-penalty-groups.json';
+
+
+describe('PenaltyDocuments service', () => {
+	let penaltyDocumentsService;
+	let callbackSpy;
+
+	beforeEach(() => {
+		penaltyDocumentsService = new PenaltyDocumentsService(doc, 'penaltyDocuments', '', '', '', '', '', '', '');
+		callbackSpy = sinon.spy();
+	});
+	afterEach(() => {
+		doc.get.restore();
+		doc.put.restore();
+		callbackSpy.resetHistory();
+	});
+
+	it('updateDocumentUponPaymentDelete', async () => {
+		sinon.stub(doc, 'put')
+			.returns({
+				promise: () => Promise.resolve('put resolved'),
+			});
+		/**
+		 * Mock for db.get in updateDocumentUponPaymentDelete.
+		 * _tryUpdatePenaltyGroupToUnpaidStatus is stubbed so will not be called.
+		 */
+		sinon.stub(doc, 'get').returns({
+			promise: () => Promise.resolve({
+				Item: {
+					Value: {},
+					ID: 'abc123def45',
+					Enabled: true,
+					penaltyGroupId: 'groupIdPen',
+					PenaltyDocumentIds: ['doc1', 'doc2'],
+					inPenaltyGroup: true,
+				},
+			}),
+		});
+		const mockPenaltyGroup = mockPenaltyGroupsData.find((group) => { return group.ID === '46xu68x7o6b'; });
+		sinon.stub(penaltyDocumentsService, '_tryUpdatePenaltyGroupToUnpaidStatus').callsFake(() => mockPenaltyGroup);
+		await penaltyDocumentsService.updateDocumentUponPaymentDelete({ id: 'abcdefg123', paymentStatus: 'UNPAID' }, callbackSpy);
+		sinon.assert.calledWith(callbackSpy, null, sinon.match({
+			statusCode: 200,
+		}));
+	});
+});

--- a/src/test/reflectPaymentDeletion.serviceInt.js
+++ b/src/test/reflectPaymentDeletion.serviceInt.js
@@ -1,0 +1,41 @@
+import supertest from 'supertest';
+
+
+const url = 'http://localhost:3001/documents';
+const request = supertest(url);
+
+describe('payment deletion reflection', () => {
+	context('updating upon payment deletion', () => {
+		context('update single doc', () => {
+			it('updates a single document', (done) => {
+				request.put('/updateUponPaymentDelete')
+					.set('Context-Type', 'application/json')
+					.set('authorization', 'allow')
+					.send({
+						id: '820500000812_FPN',
+						paymentStatus: 'UNPAID',
+					})
+					.expect(200)
+					.end((err) => {
+						if (err) throw err;
+						done();
+					});
+			});
+		});
+		context('update multi docs', () => {
+			it('updates multiple documents', (done) => {
+				request.put('/updateMultipleUponPaymentDelete')
+					.set('Context-Type', 'application/json')
+					.set('authorization', 'allow')
+					.send({
+						penaltyDocumentIds: ['820500000878_FPN', '820500000877_FPN'],
+					})
+					.expect(200)
+					.end((err) => {
+						if (err) throw err;
+						done();
+					});
+			});
+		});
+	});
+});

--- a/src/utils/createSimpleResponse.js
+++ b/src/utils/createSimpleResponse.js
@@ -1,4 +1,4 @@
-export default ({ body = {}, statusCode = 200, error }) => {
+export default ({ body = {}, statusCode = 200, error = undefined }) => {
 	const response = {
 		status: statusCode,
 		item: body,


### PR DESCRIPTION
Add new lambda function for setting the payment status to unpaid for multiple penalty documents. Also updates a single parent penalty group to unpaid when its status is "PAID".