### PR TITLE
RSP-1828: Allow updateItem to update old cancelled penalty document

### DIFF
--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -21,6 +21,7 @@ const lambda = new Lambda({ region: 'eu-west-1' });
 const docTypeMapping = ['FPN', 'IM', 'CDN'];
 const portalOrigin = 'PORTAL';
 const appOrigin = 'APP';
+const newHashConstant = '<NewHash>';
 
 export default class PenaltyDocument {
 
@@ -680,7 +681,7 @@ export default class PenaltyDocument {
 	updateItem(item) {
 		const timestamp = getUnixTime();
 		const key = item.ID;
-		const clientHash = item.Hash ? item.Hash : '<NewHash>';
+		const clientHash = item.Hash ? item.Hash : newHashConstant;
 		const { Value, Enabled } = item;
 
 		// save values before removing them on insert
@@ -720,7 +721,8 @@ export default class PenaltyDocument {
 				ID: key,
 			},
 			UpdateExpression: 'set #Value = :Value, #Hash = :Hash, #Offset = :Offset, #Enabled = :Enabled, #Origin = :Origin, #VehicleRegistration = :VehicleRegistration',
-			ConditionExpression: 'attribute_not_exists(#ID) OR (#Origin = :PortalOrigin  and attribute_exists(#ID)) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND #Hash=:clientHash)',
+			// Update if not exists, portal origin, app origin with matching hash (from app db), or if no hash from app but existing token is cancelled.
+			ConditionExpression: 'attribute_not_exists(#ID) OR (#Origin = :PortalOrigin  and attribute_exists(#ID)) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND #Hash=:clientHash) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND :isNewHash AND #Enabled = :notEnabled)',
 			ExpressionAttributeNames: {
 				'#ID': 'ID',
 				'#Hash': 'Hash',
@@ -733,6 +735,8 @@ export default class PenaltyDocument {
 			ExpressionAttributeValues: {
 				':clientHash': clientHash,
 				':Enabled': Enabled,
+				':notEnabled': false,
+				':isNewHash': clientHash === newHashConstant,
 				':Value': Value,
 				':Hash': newHash,
 				':Offset': timestamp,

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -736,7 +736,7 @@ export default class PenaltyDocument {
 				':clientHash': clientHash,
 				':Enabled': Enabled,
 				':notEnabled': false,
-				':isNewHash': clientHash === newHashConstant,
+				':isNewHash': clientHash === newHashConstant || clientHash === 'New',
 				':newHashTrue': true,
 				':Value': Value,
 				':Hash': newHash,

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -722,7 +722,7 @@ export default class PenaltyDocument {
 			},
 			UpdateExpression: 'set #Value = :Value, #Hash = :Hash, #Offset = :Offset, #Enabled = :Enabled, #Origin = :Origin, #VehicleRegistration = :VehicleRegistration',
 			// Update if not exists, portal origin, app origin with matching hash (from app db), or if no hash from app but existing token is cancelled.
-			ConditionExpression: 'attribute_not_exists(#ID) OR (#Origin = :PortalOrigin  and attribute_exists(#ID)) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND #Hash=:clientHash) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND :isNewHash AND #Enabled = :notEnabled)',
+			ConditionExpression: 'attribute_not_exists(#ID) OR (#Origin = :PortalOrigin  and attribute_exists(#ID)) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND #Hash=:clientHash) OR (#Origin = :AppOrigin and attribute_exists(#ID) AND :isNewHash = :newHashTrue AND #Enabled = :notEnabled)',
 			ExpressionAttributeNames: {
 				'#ID': 'ID',
 				'#Hash': 'Hash',
@@ -737,6 +737,7 @@ export default class PenaltyDocument {
 				':Enabled': Enabled,
 				':notEnabled': false,
 				':isNewHash': clientHash === newHashConstant,
+				':newHashTrue': true,
 				':Value': Value,
 				':Hash': newHash,
 				':Offset': timestamp,


### PR DESCRIPTION
Current behaviour is a penalty can only override an existing payment code if it is uploaded with the same hash. The phone will remember the hash if the cancelled penalty is in the phone's memory. If the cancelled penalty is not in the phone's memory, it will upload the token without a hash. This is a fix  to allow overrides of existing penalty codes if the clientHash is undefined and the existing penalty is disabled (cancelled).