### PR TITLE
RSP-1360: Offline penalty payment

### DIFF
--- a/src/functions/create.js
+++ b/src/functions/create.js
@@ -22,5 +22,6 @@ export default async (event) => {
 
 	const data = JSON.parse(event.body);
 	// id body document
+	delete data.Value.paymentStatus;
 	return penaltyDocuments.createDocument(data);
 };

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -772,7 +772,7 @@ export default class PenaltyDocument {
 			savedPaymentDate = Number(` ${item.Value.paymentDate}`.slice(1));
 		}
 
-		delete item.Value.paymentStatus;
+		// Don't delete payment status from payment data as reg search relies on it
 		delete item.Value.paymentAuthCode;
 		delete item.Value.paymentDate;
 		delete item.Value.paymentRef;

--- a/src/services/penaltyDocuments.js
+++ b/src/services/penaltyDocuments.js
@@ -389,8 +389,6 @@ export default class PenaltyDocument {
 	}
 
 	async createDocument(body) {
-
-		delete body.Value.paymentStatus;
 		delete body.paymentAuthCode;
 		delete body.paymentDate;
 		delete body.paymentRef;

--- a/src/services/penaltyDocumentsTests/createDocument.unit.js
+++ b/src/services/penaltyDocumentsTests/createDocument.unit.js
@@ -67,6 +67,8 @@ describe('createDocument', () => {
 				expect(response.statusCode).toBe(200);
 				const responseBody = JSON.parse(response.body);
 				expect(responseBody.Value.paymentStatus).toBe('PAID');
+				const putParams = dbPut.getCall(0).args[0];
+				expect(putParams.Item.Value.paymentStatus).toBe('PAID');
 			});
 		});
 	});

--- a/src/services/penaltyDocumentsTests/updateDocumentWithPayment.unit.js
+++ b/src/services/penaltyDocumentsTests/updateDocumentWithPayment.unit.js
@@ -117,7 +117,6 @@ describe('updateDocumentWithPayment', () => {
 			sinon.assert.calledOnce(createDocument);
 			sinon.assert.notCalled(putStub);
 			sinon.assert.notCalled(sendPaymentNotification);
-			// Assert createDocument is called with the correct payment status
 			const createDocumentParams = createDocument.getCall(0).args[0];
 			expect(createDocumentParams.Value.paymentStatus).toBe('PAID');
 		});

--- a/src/services/penaltyDocumentsTests/updateDocumentWithPayment.unit.js
+++ b/src/services/penaltyDocumentsTests/updateDocumentWithPayment.unit.js
@@ -117,6 +117,9 @@ describe('updateDocumentWithPayment', () => {
 			sinon.assert.calledOnce(createDocument);
 			sinon.assert.notCalled(putStub);
 			sinon.assert.notCalled(sendPaymentNotification);
+			// Assert createDocument is called with the correct payment status
+			const createDocumentParams = createDocument.getCall(0).args[0];
+			expect(createDocumentParams.Value.paymentStatus).toBe('PAID');
 		});
 	});
 


### PR DESCRIPTION
### Description

This issue was found by the vehicle registration showing 'UNPAID' for paid penalties when the penalty was paid before being uploaded. The issue is due to the document not having the payment status in its `Value`.

### Solution for payment of penalty document

When a penalty document is paid before it is upload (e.g. when the mobile app is offline), a dummy penalty document is created. This dummy document was missing the payment status which is usually set. Moved `delete paymentStatus` to the `create` lambda function so the payment status is no longer deleted for dummy documents (when `updateWithPayment` is invoked).

### Solution for upload of penalty document after payment

The second issue was with `updateMulti` where we retrieve the existing payment data but delete it from the penalty document's value when calling `updateItem` on Dynamo. No longer deleting `paymentStatus` there.