### PR TITLE
feat: New release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  SOURCE_ZIP: master.zip
+  KEY_PATH: backend
+
+jobs:
+
+  lambdas:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.json.outputs.MATRIX }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read in lambdas names from JSON
+        id: json
+        run: |
+          echo "MATRIX=$(jq -c . < ./lambdas.json)" >> $GITHUB_OUTPUT
+
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    needs: [ lambdas ]
+    strategy:
+      matrix:
+        lambdaName: ${{ fromJSON(needs.lambdas.outputs.matrix).lambdas }}
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.RSP_AWS_ACCOUNT }}:role/GithubActionsRole
+          role-session-name: GithubActionsSession
+          aws-region: ${{ secrets.RSP_AWS_REGION }}
+      - name: Upload to s3
+        run: >
+          aws s3api copy-object
+          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/${{ env.SOURCE_ZIP }}
+          --key ${{ env.KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ github.ref_name }}.zip
+          --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- Copies latest master zip archive in S3 and renames it to the new release archive using the tag name
- Update CI workflow to only run on branch pushes and not tag pushes
- Ticket RSP-2095

Related issue: [RSP-2095](https://dvsa.atlassian.net/browse/RSP-2095)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
