### PR TITLE
deps: updated dvsa/rsp-validation to 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "rsp-documents-service",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rsp-documents-service",
-      "version": "1.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.1",
-        "@dvsa/rsp-validation": "^1.8.0",
+        "@dvsa/rsp-validation": "^1.9.1",
         "aws-sdk": "^2.1249.0",
         "core-js": "^3.26.0",
         "install": "^0.13.0",
@@ -2841,9 +2841,9 @@
       }
     },
     "node_modules/@dvsa/rsp-validation": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.8.0.tgz",
-      "integrity": "sha512-hNmKOSjt0tzdafZsXDR0dBY2bE4LfkzeHtlPnqPDCWxVEBByRv4olhm5aJTpobrguzRL6SO2pQO8osFjWHaAYQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
+      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
       "dependencies": {
         "joi": "^17.7.0"
       }
@@ -17858,9 +17858,9 @@
       "dev": true
     },
     "@dvsa/rsp-validation": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.8.0.tgz",
-      "integrity": "sha512-hNmKOSjt0tzdafZsXDR0dBY2bE4LfkzeHtlPnqPDCWxVEBByRv4olhm5aJTpobrguzRL6SO2pQO8osFjWHaAYQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/rsp-validation/-/rsp-validation-1.9.1.tgz",
+      "integrity": "sha512-Ro9Fus5TkYLdJhathVi2ghLc5xa00Vt2xDmXCT64Mbu+TdqDzgAPs01TT4V3lANrxIPpsof4bq9Xbjc7Lt/M9g==",
       "requires": {
         "joi": "^17.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.20.1",
-    "@dvsa/rsp-validation": "^1.8.0",
+    "@dvsa/rsp-validation": "^1.9.1",
     "aws-sdk": "^2.1249.0",
     "core-js": "^3.26.0",
     "install": "^0.13.0",


### PR DESCRIPTION
## Description

- The dvsa/rsp-validation package has been updated to 1.9.1 (latest) to incorporate new changes.

Related issue: [RSP-2196](https://dvsa.atlassian.net/browse/RSP-2195?atlOrigin=eyJpIjoiZjFmYjYzZTM5NWNjNGM3ODlmMmRjZTVlYjYzYThlYjEiLCJwIjoiaiJ9)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
